### PR TITLE
Add initial version of OOPS team etiquette

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository is a place where we store our team processes, standards, and inf
 ## Contents
 
 - [Guides](/guides)
+  - [Etiquette](/guides/etiquette.md)
 - [Processes](/processes)
 - [Standards](/standards)
 

--- a/guides/etiquette.md
+++ b/guides/etiquette.md
@@ -4,7 +4,9 @@ To ensure homgenous team working and enthusiastically transform real-time partne
 
 ## Avoid idle gossip
 
-If the gossip is informative and interesting then that is acceptable. Ensure you share it with as many people as possible so no team member feels left out. However refrain from idle (boring and uninformative) gossip.
+If the gossip is informative and interesting then that is acceptable. Ensure you share it with as many people as possible so no team member feels left out.
+
+We believe gossip is good for morale, however refrain from idle (boring and uninformative) gossip.
 
 ## Use your own mug
 

--- a/guides/etiquette.md
+++ b/guides/etiquette.md
@@ -1,0 +1,17 @@
+# Etiquette
+
+To ensure homgenous team working and enthusiastically transform real-time partnerships we have produced this guide on team ettiquette.
+
+## Avoid idle gossip
+
+If the gossip is informative and interesting then that is acceptable. Ensure you share it with as many people as possible so no team member feels left out. However refrain from idle (boring and uninformative) gossip.
+
+## Use your own mug
+
+On starting with OOPS you are expected to provide your own mug (the standard for mug selection is not yet written so please speak to a colleague for details before purchasing one).
+
+You should only ever use your own mug and not that of a colleagues. You may handle another colleagues mug but only once you have received written permission to do so. Email confirmation is acceptable.
+
+## Cake restraint
+
+On officially appointed days, a colleague may bring a cake into the office for the team. **DO NOT** go back for seconds until everyone in the team has had a slice. This includes those on annual leave, away from the office, or those on long term sick.


### PR DESCRIPTION
New members to the team will benefit from knowing what the existing team considers to be good office etiquette. This should reduce the chance of conflict or resentment.

This change adds an initial version of a guide on etiquette.